### PR TITLE
Fix/add bundler to package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@docknetwork/wallet-sdk-core",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/packages/credentials/lib/index.js
+++ b/packages/credentials/lib/index.js
@@ -109,9 +109,9 @@ export class Credentials {
   /**
    * Get instance
    *
-   * @returns {Promise<Wallet>}
+   * @returns {Promise<Credentials>}
    */
-  static getInstance(): Wallet {
+  static getInstance(): Credentials {
     if (!this.instance) {
       this.instance = new Credentials();
     }

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@docknetwork/wallet-sdk-credentials",
-    "version": "0.1.0",
+    "version": "0.1.2",
     "dependencies": {
         "@docknetwork/wallet-sdk-core": "^0.1.3",
         "axios": "^0.25.0"

--- a/packages/react-native/.gitignore
+++ b/packages/react-native/.gitignore
@@ -1,2 +1,0 @@
-public/bundle.js
-public/bundle.js.LICENSE.txt

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@docknetwork/wallet-sdk-react-native",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "dependencies": {
         "@polkadot/keyring": "^7.2.1",
         "@polkadot/types-known": "5.6.1",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@docknetwork/wallet-sdk-transactions",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "dependencies": {
         "@polkadot/keyring": "^7.2.1",
         "@polkadot/types-known": "5.6.1",


### PR DESCRIPTION
Adding the bundle js, so that we don't need to compile that in the react native app when using the sdk.

As a improvement we can add the bundle generation process to the CI pipeline