### PR TITLE
try/catch around getCredentialValidityStatus

### DIFF
--- a/packages/react-native/lib/credentials/credentialHooks.js
+++ b/packages/react-native/lib/credentials/credentialHooks.js
@@ -34,8 +34,17 @@ export function getCredentialTimestamp(credential) {
 
   return new Date(credential.issuanceDate).getTime() || 0;
 }
-function getCredentialValidityStatus(credential) {
-  return credentialServiceRPC.verifyCredential({credential});
+
+async function getCredentialValidityStatus(credential) {
+  try {
+    const result = await credentialServiceRPC.verifyCredential({credential});
+    return result;
+  } catch (error) {
+    return {
+      verified: false,
+      error,
+    };
+  }
 }
 
 export function useCredentialUtils() {


### PR DESCRIPTION
sometimes it can throw errors, best to catch them and return as not verified