### PR TITLE
Dckm 461 fixing issues with PEX optional fields

### DIFF
--- a/packages/wasm/src/services/pex/service.ts
+++ b/packages/wasm/src/services/pex/service.ts
@@ -17,40 +17,40 @@ const pex: PEX = new PEX();
  * This is a temporary workaround until the issue is fixed in the @sphereon/pex library
  **/
 export function removeOptionalAttribute(presentationDefinition) {
-  // presentationDefinition.input_descriptors.forEach(inputDescriptor => {
-  //   if (!inputDescriptor.constraints?.fields?.length) {
-  //     return;
-  //   }
-  //   // Filter the optional fields
-  //   // If we include those fields, it might exclude few credentials from the resulsts
-  //   // e.g: Expiration date as optional, a credenntial without expiration date should be included
-  //   inputDescriptor.constraints.fields =
-  //     inputDescriptor.constraints.fields.filter(
-  //       field => field.optional !== true,
-  //     );
+  presentationDefinition.input_descriptors.forEach(inputDescriptor => {
+    if (!inputDescriptor.constraints?.fields?.length) {
+      return;
+    }
+    // Filter the optional fields
+    // If we include those fields, it might exclude few credentials from the resulsts
+    // e.g: Expiration date as optional, a credenntial without expiration date should be included
+    inputDescriptor.constraints.fields =
+      inputDescriptor.constraints.fields.filter(
+        field => field.optional !== true,
+      );
 
-  //   // Removes the optinal attributes from the fields
-  //   // It applies in case optional: false
-  //   // The field is required, but pex doesn't support the attribute
-  //   inputDescriptor.constraints.fields.forEach(field => {
-  //     if (field.optional !== undefined) {
-  //       delete field.optional;
-  //     }
-  //   });
+    // Removes the optinal attributes from the fields
+    // It applies in case optional: false
+    // The field is required, but pex doesn't support the attribute
+    inputDescriptor.constraints.fields.forEach(field => {
+      if (field.optional !== undefined) {
+        delete field.optional;
+      }
+    });
 
-  //   // There is a case where ALL fields are optional
-  //   // If we remove all fields, it will cause an error with PEX
-  //   // So, we add a placeholder field to avoid the error
-  //   if (inputDescriptor.constraints.fields.length === 0) {
-  //     inputDescriptor.constraints.fields.push({
-  //       path: '$.id',
-  //     });
-  //   }
-  // });
+    // There is a case where ALL fields are optional
+    // If we remove all fields, it will cause an error with PEX
+    // So, we add a placeholder field to avoid the error
+    if (inputDescriptor.constraints.fields.length === 0) {
+      inputDescriptor.constraints.fields.push({
+        path: '$.id',
+      });
+    }
+  });
 
-  // if (!presentationDefinition.id) {
-  //   presentationDefinition.id = 'placeholder';
-  // }
+  if (!presentationDefinition.id) {
+    presentationDefinition.id = 'id';
+  }
 
   return presentationDefinition;
 }

--- a/packages/wasm/src/services/pex/tests/pex-service.test.js
+++ b/packages/wasm/src/services/pex/tests/pex-service.test.js
@@ -363,9 +363,6 @@ describe('Pex Examples', () => {
             constraints: {
               fields: [
                 {
-                  path: ['$.credentialSubject.id'],
-                },
-                {
                   path: ['$.type[*]'],
                   filter: {
                     const: '',
@@ -383,9 +380,10 @@ describe('Pex Examples', () => {
       };
 
       expect(getFieldsWithOptionalAttributes(template)).toBe(2);
-      expect(
-        getFieldsWithOptionalAttributes(removeOptionalAttribute(template)),
-      ).toBe(0);
+
+      let result = removeOptionalAttribute(template);
+      expect(getFieldsWithOptionalAttributes(result)).toBe(0);
+      expect(result.input_descriptors[0].constraints.fields.length).toBe(1);
 
       template = {
         id: 'income_test',
@@ -413,9 +411,10 @@ describe('Pex Examples', () => {
       };
 
       expect(getFieldsWithOptionalAttributes(template)).toBe(1);
-      expect(
-        getFieldsWithOptionalAttributes(removeOptionalAttribute(template)),
-      ).toBe(0);
+
+      result = removeOptionalAttribute(template);
+      expect(getFieldsWithOptionalAttributes(result)).toBe(0);
+      expect(result.input_descriptors[0].constraints.fields.length).toBe(1);
 
       template = {
         id: 'income_test',
@@ -436,9 +435,33 @@ describe('Pex Examples', () => {
       };
 
       expect(getFieldsWithOptionalAttributes(template)).toBe(0);
-      expect(
-        getFieldsWithOptionalAttributes(removeOptionalAttribute(template)),
-      ).toBe(0);
+      result = removeOptionalAttribute(template);
+      expect(getFieldsWithOptionalAttributes(result)).toBe(0);
+      expect(result.input_descriptors[0].constraints.fields.length).toBe(1);
+
+      template = {
+        id: 'income_test',
+        input_descriptors: [
+          {
+            id: 'Credential 1',
+            name: 'optional field',
+            purpose: 'optional field',
+            constraints: {
+              fields: [
+                {
+                  path: ['$.credentialSubject.id'],
+                  optional: true,
+                },
+              ],
+            },
+          },
+        ],
+      };
+
+      expect(getFieldsWithOptionalAttributes(template)).toBe(1);
+      result = removeOptionalAttribute(template);
+      expect(getFieldsWithOptionalAttributes(result)).toBe(0);
+      expect(result.input_descriptors[0].constraints.fields.length).toBe(1);
     });
   });
 });


### PR DESCRIPTION
There are some additional use cases we are not handling. It was breaking during the wallet to wallet verification flow when all fields are optional.